### PR TITLE
修復 readme.md 系統架構圖

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ graph TD
 
     subgraph "自動化回應與通知"
         E --> J[動作執行器 Action Executor];
-        J --> K[安全設備 API <br/> (防火牆, EDR ...)];
+        J --> K["安全設備 API<br/>(防火牆, EDR ...)"];
         E --> L[通知服務 (Slack/Email)];
-        E --> M[人工審批介面 <br/> (Human-in-the-Loop)];
+        E --> M["人工審批介面<br/>(Human-in-the-Loop)"];
     end
 
     subgraph "監控層"


### PR DESCRIPTION
Fix Mermaid diagram rendering issue in `README.md` by correcting line break syntax in node labels.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-41ac2eb1-35c0-4937-9297-1ead644f006c) · [Cursor](https://cursor.com/background-agent?bcId=bc-41ac2eb1-35c0-4937-9297-1ead644f006c)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)