### PR TITLE
Apply index template for vector search

### DIFF
--- a/wazuh-docker/single-node/ai-agent-project/app/VECTOR_FIELD_ERROR_SOLUTION.md
+++ b/wazuh-docker/single-node/ai-agent-project/app/VECTOR_FIELD_ERROR_SOLUTION.md
@@ -1,0 +1,173 @@
+# 向量欄位錯誤解決方案
+
+## 錯誤訊息
+```
+ERROR - Vector search failed: RequestError(400, '{"error":... "reason":"failed to create query: Field 'alert_vector' is not knn_vector type."...}')
+```
+
+## 問題分析
+
+### 錯誤含義
+這個錯誤表示 OpenSearch 資料庫中的 `alert_vector` 欄位不是正確的向量類型。當 AI Agent 嘗試執行向量相似度搜尋時，OpenSearch 無法將該欄位識別為可進行 k-NN（k-nearest neighbors）搜尋的向量欄位。
+
+### 根本原因
+1. **索引模板未套用**：雖然已定義了正確的索引模板（`wazuh-alerts-vector-template.json`），但該模板可能尚未套用到 OpenSearch
+2. **既有索引問題**：現有的 `wazuh-alerts-*` 索引可能在套用模板之前就已建立，因此沒有正確的向量欄位映射
+3. **欄位類型不匹配**：`alert_vector` 欄位可能被建立為普通的數值陣列，而非 `dense_vector` 類型
+
+## 解決方案
+
+### 方案 1：使用快速修正腳本（推薦）
+
+我已建立兩個修正腳本：
+
+1. **`quick_fix_vector.py`** - 自動化快速修正腳本
+2. **`fix_vector_field.py`** - 互動式詳細修正腳本
+
+### 方案 2：手動修正步驟
+
+#### 步驟 1：套用索引模板
+```bash
+# 在容器內執行
+curl -X PUT "https://wazuh.indexer:9200/_index_template/wazuh-alerts-vector-template" \
+  -H "Content-Type: application/json" \
+  -u admin:SecretPassword \
+  -k \
+  -d @wazuh-alerts-vector-template.json
+```
+
+#### 步驟 2：重新索引現有資料
+```bash
+# 建立新索引（會自動套用模板）
+curl -X PUT "https://wazuh.indexer:9200/wazuh-alerts-4.x-2024.01.01-temp" \
+  -u admin:SecretPassword \
+  -k
+
+# 重新索引資料
+curl -X POST "https://wazuh.indexer:9200/_reindex" \
+  -H "Content-Type: application/json" \
+  -u admin:SecretPassword \
+  -k \
+  -d '{
+    "source": {"index": "wazuh-alerts-4.x-2024.01.01"},
+    "dest": {"index": "wazuh-alerts-4.x-2024.01.01-temp"}
+  }'
+
+# 刪除舊索引並重新命名
+curl -X DELETE "https://wazuh.indexer:9200/wazuh-alerts-4.x-2024.01.01" \
+  -u admin:SecretPassword \
+  -k
+
+curl -X POST "https://wazuh.indexer:9200/_aliases" \
+  -H "Content-Type: application/json" \
+  -u admin:SecretPassword \
+  -k \
+  -d '{
+    "actions": [
+      {"add": {"index": "wazuh-alerts-4.x-2024.01.01-temp", "alias": "wazuh-alerts-4.x-2024.01.01"}}
+    ]
+  }'
+```
+
+### 方案 3：Docker Compose 整合
+
+在 `docker-compose.yml` 中加入初始化容器：
+
+```yaml
+services:
+  opensearch-init:
+    image: curlimages/curl:latest
+    depends_on:
+      - wazuh.indexer
+    volumes:
+      - ./ai-agent-project/app/wazuh-alerts-vector-template.json:/template.json
+    command: |
+      sh -c "
+        sleep 30 &&
+        curl -X PUT 'https://wazuh.indexer:9200/_index_template/wazuh-alerts-vector-template' \
+          -H 'Content-Type: application/json' \
+          -u admin:SecretPassword \
+          -k \
+          -d @/template.json
+      "
+```
+
+## 驗證修正
+
+### 檢查索引模板
+```bash
+curl -X GET "https://wazuh.indexer:9200/_index_template/wazuh-alerts-vector-template" \
+  -u admin:SecretPassword \
+  -k
+```
+
+### 檢查索引映射
+```bash
+curl -X GET "https://wazuh.indexer:9200/wazuh-alerts-*/_mapping/field/alert_vector" \
+  -u admin:SecretPassword \
+  -k
+```
+
+### 測試向量搜尋
+```python
+# 在 Python 中測試
+from opensearchpy import OpenSearch
+
+client = OpenSearch(
+    hosts=['https://wazuh.indexer:9200'],
+    http_auth=('admin', 'SecretPassword'),
+    use_ssl=True,
+    verify_certs=False
+)
+
+# 測試向量搜尋
+test_vector = [0.1] * 768
+response = client.search(
+    index="wazuh-alerts-*",
+    body={
+        "query": {
+            "knn": {
+                "alert_vector": {
+                    "vector": test_vector,
+                    "k": 5
+                }
+            }
+        }
+    }
+)
+```
+
+## 預防措施
+
+1. **確保索引模板優先套用**：在建立任何 Wazuh 索引之前，先套用向量索引模板
+2. **定期驗證**：使用 `verify_vectorization.py` 腳本定期檢查向量化狀態
+3. **監控錯誤**：在日誌中監控向量搜尋相關錯誤
+
+## 技術細節
+
+### 正確的欄位映射
+```json
+{
+  "alert_vector": {
+    "type": "dense_vector",
+    "dims": 768,
+    "index": true,
+    "similarity": "cosine",
+    "index_options": {
+      "type": "hnsw",
+      "m": 16,
+      "ef_construction": 512
+    }
+  }
+}
+```
+
+### 關鍵參數說明
+- `type: dense_vector`：定義為密集向量類型
+- `dims: 768`：Gemini text-embedding-004 模型的向量維度
+- `similarity: cosine`：使用餘弦相似度計算
+- `type: hnsw`：使用 HNSW (Hierarchical Navigable Small World) 演算法進行高效搜尋
+
+## 結論
+
+這個錯誤的修正需要重新建立具有正確映射的索引。雖然過程涉及重新索引資料，但這是確保向量搜尋功能正常運作的必要步驟。建議在生產環境中執行前先在測試環境驗證。

--- a/wazuh-docker/single-node/ai-agent-project/app/fix_vector_field.py
+++ b/wazuh-docker/single-node/ai-agent-project/app/fix_vector_field.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+修正 OpenSearch 中 alert_vector 欄位類型錯誤的腳本
+
+問題：Field 'alert_vector' is not knn_vector type
+原因：現有索引沒有正確的向量欄位映射
+
+解決方案：
+1. 確保索引模板已正確套用
+2. 重新索引現有資料到新索引
+3. 驗證向量搜尋功能
+
+作者：資深 Python 工程師
+"""
+
+import os
+import asyncio
+import logging
+import json
+from datetime import datetime
+from opensearchpy import AsyncOpenSearch, AsyncHttpConnection
+from typing import Dict, List, Optional
+
+# 設置日誌
+logging.basicConfig(
+    level=logging.INFO, 
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# OpenSearch 連線配置
+OPENSEARCH_URL = os.getenv("OPENSEARCH_URL", "https://wazuh.indexer:9200")
+OPENSEARCH_USER = os.getenv("OPENSEARCH_USER", "admin")
+OPENSEARCH_PASSWORD = os.getenv("OPENSEARCH_PASSWORD", "SecretPassword")
+
+
+class VectorFieldFixer:
+    """修正向量欄位問題的主要類別"""
+    
+    def __init__(self):
+        self.client = None
+        self.template_name = "wazuh-alerts-vector-template"
+        
+    async def __aenter__(self):
+        """非同步上下文管理器進入"""
+        self.client = AsyncOpenSearch(
+            hosts=[OPENSEARCH_URL],
+            http_auth=(OPENSEARCH_USER, OPENSEARCH_PASSWORD),
+            use_ssl=True,
+            verify_certs=False,
+            ssl_show_warn=False,
+            connection_class=AsyncHttpConnection
+        )
+        return self
+        
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """非同步上下文管理器退出"""
+        if self.client:
+            await self.client.close()
+            
+    async def check_existing_indices(self) -> List[str]:
+        """檢查現有的 Wazuh 索引"""
+        logger.info("🔍 檢查現有的 Wazuh 索引...")
+        
+        try:
+            # 獲取所有 wazuh-alerts-* 索引
+            indices = await self.client.indices.get("wazuh-alerts-*")
+            index_list = list(indices.keys())
+            
+            logger.info(f"找到 {len(index_list)} 個 Wazuh 索引:")
+            for idx in index_list:
+                logger.info(f"  - {idx}")
+                
+            return index_list
+            
+        except Exception as e:
+            logger.error(f"檢查索引失敗: {str(e)}")
+            return []
+            
+    async def check_index_mapping(self, index_name: str) -> Dict:
+        """檢查索引的映射配置"""
+        try:
+            mapping = await self.client.indices.get_mapping(index=index_name)
+            properties = mapping[index_name]['mappings'].get('properties', {})
+            
+            # 檢查 alert_vector 欄位
+            if 'alert_vector' in properties:
+                vector_config = properties['alert_vector']
+                logger.info(f"\n📋 索引 {index_name} 的 alert_vector 欄位配置:")
+                logger.info(f"  類型: {vector_config.get('type', 'undefined')}")
+                
+                if vector_config.get('type') == 'dense_vector':
+                    logger.info("  ✅ 欄位類型正確")
+                    logger.info(f"  維度: {vector_config.get('dims', 'undefined')}")
+                    logger.info(f"  相似度: {vector_config.get('similarity', 'undefined')}")
+                else:
+                    logger.warning(f"  ❌ 欄位類型不正確: {vector_config.get('type')}")
+                    
+                return vector_config
+            else:
+                logger.warning(f"  ❌ 索引 {index_name} 沒有 alert_vector 欄位")
+                return {}
+                
+        except Exception as e:
+            logger.error(f"檢查映射失敗: {str(e)}")
+            return {}
+            
+    async def ensure_index_template(self) -> bool:
+        """確保索引模板已正確設置"""
+        logger.info("\n🔧 確保索引模板已正確設置...")
+        
+        template_body = {
+            "index_patterns": ["wazuh-alerts-*"],
+            "priority": 1,
+            "template": {
+                "settings": {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 1,
+                    "index": {
+                        "knn": True,
+                        "knn.algo_param.ef_search": 512
+                    }
+                },
+                "mappings": {
+                    "properties": {
+                        "alert_vector": {
+                            "type": "dense_vector",
+                            "dims": 768,
+                            "index": True,
+                            "similarity": "cosine",
+                            "index_options": {
+                                "type": "hnsw",
+                                "m": 16,
+                                "ef_construction": 512
+                            }
+                        },
+                        "ai_analysis": {
+                            "type": "object",
+                            "properties": {
+                                "triage_report": {
+                                    "type": "text",
+                                    "analyzer": "standard"
+                                },
+                                "provider": {
+                                    "type": "keyword"
+                                },
+                                "timestamp": {
+                                    "type": "date"
+                                },
+                                "risk_level": {
+                                    "type": "keyword"
+                                },
+                                "vector_dimension": {
+                                    "type": "integer"
+                                },
+                                "processing_time_ms": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        try:
+            # 刪除舊的模板（如果存在）
+            try:
+                await self.client.indices.delete_index_template(name=self.template_name)
+                logger.info("  已刪除舊的索引模板")
+            except:
+                pass
+                
+            # 建立新的模板
+            response = await self.client.indices.put_index_template(
+                name=self.template_name,
+                body=template_body
+            )
+            
+            if response.get('acknowledged'):
+                logger.info("  ✅ 索引模板建立成功")
+                return True
+            else:
+                logger.error("  ❌ 索引模板建立失敗")
+                return False
+                
+        except Exception as e:
+            logger.error(f"  ❌ 設置索引模板時發生錯誤: {str(e)}")
+            return False
+            
+    async def reindex_with_correct_mapping(self, source_index: str) -> bool:
+        """重新索引資料到具有正確映射的新索引"""
+        logger.info(f"\n📦 重新索引 {source_index}...")
+        
+        # 產生新索引名稱
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        temp_index = f"{source_index}-fixed-{timestamp}"
+        
+        try:
+            # 建立新索引（會自動套用模板）
+            await self.client.indices.create(index=temp_index)
+            logger.info(f"  建立臨時索引: {temp_index}")
+            
+            # 執行重新索引
+            reindex_body = {
+                "source": {
+                    "index": source_index
+                },
+                "dest": {
+                    "index": temp_index
+                }
+            }
+            
+            response = await self.client.reindex(body=reindex_body)
+            total = response.get('total', 0)
+            logger.info(f"  重新索引完成: 共 {total} 筆文件")
+            
+            # 刪除舊索引
+            await self.client.indices.delete(index=source_index)
+            logger.info(f"  已刪除舊索引: {source_index}")
+            
+            # 建立別名指向新索引
+            await self.client.indices.put_alias(index=temp_index, name=source_index)
+            logger.info(f"  建立別名: {source_index} -> {temp_index}")
+            
+            return True
+            
+        except Exception as e:
+            logger.error(f"  ❌ 重新索引失敗: {str(e)}")
+            return False
+            
+    async def test_vector_search(self, index_name: str) -> bool:
+        """測試向量搜尋功能"""
+        logger.info(f"\n🧪 測試向量搜尋功能 (索引: {index_name})...")
+        
+        try:
+            # 建立測試向量
+            test_vector = [0.1] * 768
+            
+            # 執行向量搜尋
+            search_body = {
+                "size": 5,
+                "query": {
+                    "knn": {
+                        "alert_vector": {
+                            "vector": test_vector,
+                            "k": 5
+                        }
+                    }
+                }
+            }
+            
+            response = await self.client.search(
+                index=index_name,
+                body=search_body
+            )
+            
+            hits = response.get('hits', {}).get('total', {}).get('value', 0)
+            logger.info(f"  ✅ 向量搜尋成功，找到 {hits} 筆結果")
+            return True
+            
+        except Exception as e:
+            error_msg = str(e)
+            if "is not knn_vector type" in error_msg:
+                logger.error(f"  ❌ 向量搜尋失敗: 欄位類型錯誤")
+            else:
+                logger.error(f"  ❌ 向量搜尋失敗: {error_msg}")
+            return False
+            
+    async def fix_all_indices(self) -> None:
+        """修正所有索引的向量欄位問題"""
+        logger.info("🚀 開始修正向量欄位問題...\n")
+        
+        # 1. 確保索引模板正確
+        if not await self.ensure_index_template():
+            logger.error("無法設置索引模板，程序終止")
+            return
+            
+        # 2. 檢查現有索引
+        indices = await self.check_existing_indices()
+        if not indices:
+            logger.warning("沒有找到任何 Wazuh 索引")
+            return
+            
+        # 3. 檢查並修正每個索引
+        needs_fix = []
+        for index in indices:
+            mapping = await self.check_index_mapping(index)
+            if not mapping or mapping.get('type') != 'dense_vector':
+                needs_fix.append(index)
+                
+        if not needs_fix:
+            logger.info("\n✅ 所有索引的向量欄位都已正確配置")
+            return
+            
+        logger.info(f"\n需要修正的索引: {needs_fix}")
+        
+        # 4. 詢問是否繼續
+        response = input("\n是否要修正這些索引? (y/N): ").strip().lower()
+        if response not in ['y', 'yes']:
+            logger.info("操作已取消")
+            return
+            
+        # 5. 執行修正
+        for index in needs_fix:
+            success = await self.reindex_with_correct_mapping(index)
+            if success:
+                # 測試修正後的索引
+                await self.test_vector_search(index)
+                
+        logger.info("\n🎉 修正程序完成！")
+        
+        # 6. 最終驗證
+        logger.info("\n📊 最終驗證結果:")
+        indices = await self.check_existing_indices()
+        for index in indices:
+            await self.check_index_mapping(index)
+            await self.test_vector_search(index)
+
+
+async def main():
+    """主程式入口"""
+    async with VectorFieldFixer() as fixer:
+        await fixer.fix_all_indices()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/wazuh-docker/single-node/ai-agent-project/app/quick_fix_vector.py
+++ b/wazuh-docker/single-node/ai-agent-project/app/quick_fix_vector.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+快速修正向量欄位問題的自動化腳本
+無需使用者互動，適合背景執行
+"""
+
+import os
+import asyncio
+import logging
+from datetime import datetime
+from opensearchpy import AsyncOpenSearch, AsyncHttpConnection
+
+# 設置日誌
+logging.basicConfig(
+    level=logging.INFO, 
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# OpenSearch 連線配置
+OPENSEARCH_URL = os.getenv("OPENSEARCH_URL", "https://wazuh.indexer:9200")
+OPENSEARCH_USER = os.getenv("OPENSEARCH_USER", "admin")
+OPENSEARCH_PASSWORD = os.getenv("OPENSEARCH_PASSWORD", "SecretPassword")
+
+
+async def quick_fix():
+    """快速修正向量欄位問題"""
+    client = AsyncOpenSearch(
+        hosts=[OPENSEARCH_URL],
+        http_auth=(OPENSEARCH_USER, OPENSEARCH_PASSWORD),
+        use_ssl=True,
+        verify_certs=False,
+        ssl_show_warn=False,
+        connection_class=AsyncHttpConnection
+    )
+    
+    try:
+        logger.info("🚀 開始快速修正向量欄位問題...")
+        
+        # 1. 定義索引模板
+        template_name = "wazuh-alerts-vector-template"
+        template_body = {
+            "index_patterns": ["wazuh-alerts-*"],
+            "priority": 1,
+            "template": {
+                "settings": {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 1,
+                    "index": {
+                        "knn": True,
+                        "knn.algo_param.ef_search": 512
+                    }
+                },
+                "mappings": {
+                    "properties": {
+                        "alert_vector": {
+                            "type": "dense_vector",
+                            "dims": 768,
+                            "index": True,
+                            "similarity": "cosine",
+                            "index_options": {
+                                "type": "hnsw",
+                                "m": 16,
+                                "ef_construction": 512
+                            }
+                        },
+                        "ai_analysis": {
+                            "type": "object",
+                            "properties": {
+                                "triage_report": {"type": "text", "analyzer": "standard"},
+                                "provider": {"type": "keyword"},
+                                "timestamp": {"type": "date"},
+                                "risk_level": {"type": "keyword"},
+                                "vector_dimension": {"type": "integer"},
+                                "processing_time_ms": {"type": "integer"}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        # 2. 刪除並重建索引模板
+        try:
+            await client.indices.delete_index_template(name=template_name)
+            logger.info("已刪除舊的索引模板")
+        except:
+            pass
+            
+        response = await client.indices.put_index_template(
+            name=template_name,
+            body=template_body
+        )
+        
+        if response.get('acknowledged'):
+            logger.info("✅ 索引模板建立成功")
+        else:
+            logger.error("❌ 索引模板建立失敗")
+            return
+            
+        # 3. 檢查現有索引
+        try:
+            indices = await client.indices.get("wazuh-alerts-*")
+            index_list = list(indices.keys())
+            logger.info(f"找到 {len(index_list)} 個 Wazuh 索引")
+        except:
+            logger.info("沒有找到現有的 Wazuh 索引，模板已設置完成")
+            return
+            
+        # 4. 檢查每個索引是否需要修正
+        for index_name in index_list:
+            try:
+                mapping = await client.indices.get_mapping(index=index_name)
+                properties = mapping[index_name]['mappings'].get('properties', {})
+                
+                if 'alert_vector' in properties:
+                    vector_type = properties['alert_vector'].get('type')
+                    if vector_type == 'dense_vector':
+                        logger.info(f"✅ {index_name} 的向量欄位已正確配置")
+                        continue
+                        
+                logger.info(f"⚠️  {index_name} 需要修正向量欄位")
+                
+                # 5. 重新索引
+                timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+                new_index = f"{index_name}-fixed-{timestamp}"
+                
+                # 建立新索引
+                await client.indices.create(index=new_index)
+                logger.info(f"建立新索引: {new_index}")
+                
+                # 重新索引資料
+                reindex_body = {
+                    "source": {"index": index_name},
+                    "dest": {"index": new_index}
+                }
+                
+                response = await client.reindex(body=reindex_body)
+                total = response.get('total', 0)
+                logger.info(f"重新索引完成: 共 {total} 筆文件")
+                
+                # 刪除舊索引並建立別名
+                await client.indices.delete(index=index_name)
+                await client.indices.put_alias(index=new_index, name=index_name)
+                logger.info(f"✅ {index_name} 修正完成")
+                
+            except Exception as e:
+                logger.error(f"處理 {index_name} 時發生錯誤: {str(e)}")
+                continue
+                
+        # 6. 測試向量搜尋
+        logger.info("\n測試向量搜尋功能...")
+        test_vector = [0.1] * 768
+        search_body = {
+            "size": 1,
+            "query": {
+                "knn": {
+                    "alert_vector": {
+                        "vector": test_vector,
+                        "k": 1
+                    }
+                }
+            }
+        }
+        
+        try:
+            response = await client.search(
+                index="wazuh-alerts-*",
+                body=search_body
+            )
+            logger.info("✅ 向量搜尋測試成功")
+        except Exception as e:
+            if "is not knn_vector type" in str(e):
+                logger.error("❌ 向量搜尋測試失敗：欄位類型仍然不正確")
+            else:
+                logger.warning(f"向量搜尋測試警告: {str(e)}")
+                
+        logger.info("\n🎉 向量欄位修正程序完成！")
+        
+    except Exception as e:
+        logger.error(f"修正過程發生錯誤: {str(e)}")
+        
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(quick_fix())


### PR DESCRIPTION
Ensure `alert_vector` field is correctly mapped as `knn_vector` in OpenSearch to fix vector search failures.

The error `Field 'alert_vector' is not knn_vector type` occurs because existing Wazuh alert indices in OpenSearch were created without the necessary `dense_vector` mapping for the `alert_vector` field, or the index template defining this mapping was not properly applied. This PR introduces scripts and documentation to apply the correct index template and reindex existing data, enabling the AI Agent to perform vector similarity searches.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d8e51bce-d374-4a20-ae6e-9cb2b2352b19) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d8e51bce-d374-4a20-ae6e-9cb2b2352b19)