### PR TITLE
Fix async timeout error in docker

### DIFF
--- a/wazuh-docker/single-node/ai-agent-project/app/core/scheduler.py
+++ b/wazuh-docker/single-node/ai-agent-project/app/core/scheduler.py
@@ -5,7 +5,7 @@
 
 import logging
 from datetime import datetime
-from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.events import EVENT_JOB_EXECUTED, EVENT_JOB_ERROR
 from typing import Optional
 
@@ -14,24 +14,24 @@ from .config import SCHEDULER_INTERVAL_SECONDS, SCHEDULER_MISFIRE_GRACE_TIME
 logger = logging.getLogger(__name__)
 
 # 全域排程器實例
-scheduler: Optional[BackgroundScheduler] = None
+scheduler: Optional[AsyncIOScheduler] = None
 
-def get_scheduler() -> BackgroundScheduler:
+def get_scheduler() -> AsyncIOScheduler:
     """獲取排程器實例"""
     global scheduler
     if scheduler is None:
-        scheduler = BackgroundScheduler()
+        scheduler = AsyncIOScheduler()
     return scheduler
 
 def start_scheduler():
     """啟動排程器"""
-    from services.alert_service import triage_new_alerts_sync  # 避免循環導入
+    from services.alert_service import triage_new_alerts  # 直接使用異步函數
     
     sched = get_scheduler()
     
     # 添加定時任務
     sched.add_job(
-        triage_new_alerts_sync, 
+        triage_new_alerts, 
         'interval', 
         seconds=SCHEDULER_INTERVAL_SECONDS, 
         id='agentic_triage_job', 

--- a/wazuh-docker/single-node/ai-agent-project/app/services/alert_service.py
+++ b/wazuh-docker/single-node/ai-agent-project/app/services/alert_service.py
@@ -123,10 +123,6 @@ async def triage_new_alerts():
         logger.error(f"Critical error during GraphRAG triage: {e}", exc_info=True)
         traceback.print_exc()
 
-def triage_new_alerts_sync():
-    import asyncio
-    asyncio.run(triage_new_alerts())
-
 async def process_single_alert(alert: Dict[str, Any]) -> None:
     """
     處理單個警報的完整流程


### PR DESCRIPTION
Migrate scheduler to AsyncIOScheduler and remove synchronous wrapper to resolve `RuntimeError: Timeout context manager should be used inside a task`.

The error occurred because `asyncio.run()` was called within an existing asyncio event loop managed by FastAPI, leading to conflicts. By switching to `AsyncIOScheduler` and directly calling the async function, the application now operates in a fully asynchronous manner, preventing these event loop issues.

---

[Open in Web](https://www.cursor.com/agents?id=bc-87fd1f4c-343c-406a-a88e-8e01b65efd3e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-87fd1f4c-343c-406a-a88e-8e01b65efd3e)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)